### PR TITLE
Bug/Feat: check local version identifier part of version string in pep440

### DIFF
--- a/pep440/__init__.py
+++ b/pep440/__init__.py
@@ -14,7 +14,7 @@ True
 False
 
 """
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 from argparse import ArgumentParser
 import sys
 
@@ -32,11 +32,11 @@ from .core import (
 def main() -> None:
     parser = ArgumentParser()
     parser.add_argument("version", nargs="?")
-    parser.add_argument("--verbose", nargs="?")
+    parser.add_argument("--no-check-local", action="store_false", dest="check_local")
     args = parser.parse_args()
 
     if args.version:
-        c = is_canonical(args.version)
+        c = is_canonical(args.version, check_local=args.check_local)
         if c:
             print("Version is canonical according to Pep 440")
         else:

--- a/pep440/core.py
+++ b/pep440/core.py
@@ -27,10 +27,12 @@
 # THE SOFTWARE.
 ###############################################################################
 import re
+import string
 
 posint = r"(0|[1-9]\d*)"
 
 # 0!0.0.0rc0.post0.dev0
+# pep440 also allow ...+<anythings a-zA-Z0-9.>, see later
 
 tpl_string_re = (
     r"^"  # Start
@@ -45,15 +47,38 @@ tpl_string_re = (
 string_re = tpl_string_re.format(posint=posint, postdev=posint)
 loose440re = re.compile(tpl_string_re.format(posint=posint, postdev=(posint + "?")))
 pep440re = re.compile(string_re)
+_VALID_SET = set(string.ascii_letters + string.digits + ".")
 
 
-def is_canonical(version: str, loosedev: bool=False) -> bool:
+def is_canonical(
+    version: str, loosedev: bool = False, *, check_local: bool = True
+) -> bool:
     """
     Return whether or not the version string is canonical according to Pep 440
+
+    Parameters
+    ----------
+    version : str
+        Version string to check
+    loosedev : bool, optional
+        Whether or not to accept non-PEP440 dev versions with `.dev` without
+        number suffixes. Pep440 requires a number suffix for `.devX` versions.
+        but many versions in the wild do not follow this convention.
+    check_local : bool, optional
+        pep440 allows for a local version identifier, which is a string of
+        letters, numbers, and periods, separated from as single +.
+        Check it by default. If false, assume anything after the + is valid.
     """
+    cversion, plus, local = version.partition("+")
+    if check_local:
+        if plus == "+" and not local:
+            return False
+        local_correct = set(local) <= _VALID_SET
+    else:
+        local_correct = True
     if loosedev:
-        return loose440re.match(version) is not None
-    return pep440re.match(version) is not None
+        return loose440re.match(cversion) is not None and local_correct
+    return pep440re.match(cversion) is not None and local_correct
 
 
 def assert_valid(version: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ def cli(script_runner):
         env.update(kwargs.pop("env", {}))
         env["PYTHONIOENCODING"] = "utf-8"
         kwargs["env"] = env
-        return script_runner.run(NAME, *map(str, args), **kwargs)
+        return script_runner.run([NAME, *map(str, args)], **kwargs)
 
     return run_cli
 

--- a/tests/test_pep.py
+++ b/tests/test_pep.py
@@ -36,18 +36,44 @@ not_ok = [
     "0!0.0.0rc0.post0.dev0",  # 0 epoch is not canonical
 ]
 
+local_ok = ["+abc.5", "+123", "+1.2.3rc", ""]
 
-def test_ok():
-    for version in ok:
-        assert is_canonical(version)
-        assert_valid(version)
+local_not_ok = ["+", "+a*bc", "++.", "+@16", "+1.2.3+4"]
 
 
-def test_not_ok():
-    for version in not_ok:
-        assert is_canonical(version) == False
-        with pytest.raises(AssertionError):
-            assert_valid(version)
+@pytest.mark.parametrize("local", local_ok)
+@pytest.mark.parametrize("loose", [True, False])
+@pytest.mark.parametrize("version", ok)
+def test_ok(version, loose, local):
+    assert is_canonical(version + local, loosedev=loose)
+
+
+@pytest.mark.parametrize("local", local_ok)
+@pytest.mark.parametrize("version", ok)
+def test_ok(version, local):
+    assert_valid(version + local)
+
+
+@pytest.mark.parametrize("local", local_ok)
+@pytest.mark.parametrize("version", not_ok)
+def test_not_ok_version(version, local):
+    assert is_canonical(version + local) == False
+    with pytest.raises(AssertionError):
+        assert_valid(version + local)
+
+
+@pytest.mark.parametrize("local", local_not_ok)
+@pytest.mark.parametrize("version", ok)
+def test_not_ok_local(version, local):
+    assert is_canonical(version + local) == False
+    with pytest.raises(AssertionError):
+        assert_valid(version + local)
+
+
+@pytest.mark.parametrize("local", local_not_ok)
+@pytest.mark.parametrize("version", ok)
+def test_dont_check_local(version, local):
+    assert is_canonical(version + local, check_local=False) == True
 
 
 def test_ok_loose():


### PR DESCRIPTION
Should close #3

I'm wondering if we should have an option to refuse having a local version part....